### PR TITLE
O7Correctly documented max image and video vars

### DIFF
--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -101,8 +101,8 @@ class MediaAttachment < ApplicationRecord
     },
   }.freeze
 
-  IMAGE_LIMIT = 8.megabytes
-  VIDEO_LIMIT = 40.megabytes
+  IMAGE_LIMIT = (ENV['MAX_IMAGE_SIZE'] || 8.megabytes).to_i
+  VIDEO_LIMIT = (ENV['MAX_VIDEO_SIZE'] || 40.megabytes).to_i
 
   belongs_to :account,          inverse_of: :media_attachments, optional: true
   belongs_to :status,           inverse_of: :media_attachments, optional: true


### PR DESCRIPTION
I changed the IMAGE_LIMIT and VIDEO_LIMIT variables to read from the env, or use default if not set in the env, to make it easier to change this on an instance by instance basis and make it persistent across updates.

EDIT: documented variables in .env.production.sample