### PR TITLE
Add env variable to control search limit

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::SearchController < Api::BaseController
   include Authorization
 
-  RESULTS_LIMIT = 20
+  RESULTS_LIMIT = (ENV['MAX_SEARCH_RESULTS'] || 20).to_i
 
   before_action -> { doorkeeper_authorize! :read, :'read:search' }
   before_action :require_user!


### PR DESCRIPTION
Changed the default search limit to allow a variable called MAX_SEARCH_RESULTS in the .env.production file to change the maximum search results limit.